### PR TITLE
YAML formatter: Switch `yamlfmt` to `prettierd`

### DIFF
--- a/modules/home/languages/yaml.nix
+++ b/modules/home/languages/yaml.nix
@@ -2,6 +2,6 @@
 {
   home.packages = with pkgs; [
     yaml-language-server
-    yamlfmt
+    prettierd
   ];
 }

--- a/programs/nvim/languages/yaml.nix
+++ b/programs/nvim/languages/yaml.nix
@@ -12,7 +12,7 @@
     };
 
     conform-nvim.settings.formatters_by_ft = {
-      yaml = [ "yamlfmt" ];
+      yaml = [ "prettierd" ];
     };
   };
 }


### PR DESCRIPTION
`yamlfmt` was removing intentional new lines between array items which makes the YAML unreadable.