### PR TITLE
YubiKey play sound when touch is required

### DIFF
--- a/docs/SSH.md
+++ b/docs/SSH.md
@@ -71,6 +71,37 @@ So after full setup a host has **4 GitHub entries**: primary auth + primary sign
 
 ---
 
+## Audible touch alert (macOS)
+
+The LED is unreadable in bright light, so on macOS both git paths run through thin
+wrappers (`programs/yubikey-touch-sound`, wired up in `modules/home/git.nix`) that
+play a stock system sound on a loop while the token waits for a tap, and stop the
+moment you tap. Only Apple software makes the noise: `/usr/bin/afplay` and
+`/System/Library/Sounds/Hero.aiff` — the loudest of the stock sounds, amplified
+with `afplay -v` so it cuts through outdoors. No daemon, no agent, no third-party
+package. Sound, gain and repeat interval are arguments of
+`programs/yubikey-touch-sound`.
+
+```bash
+just yubikey-test-sound   # exercises both paths; tap when you hear the alert
+```
+
+The two paths differ because OpenSSH treats them differently:
+
+| Path | Mechanism |
+| --- | --- |
+| **SSH auth** (`git push`, `ssh`) | OpenSSH's own notifier: `notify_start()` forks `$SSH_ASKPASS` when a tap is needed and SIGTERMs it once you tap. The wrapper points `SSH_ASKPASS` at the alert script, puts stderr on a pipe and sets a placeholder `DISPLAY`, because the notifier only fires when stderr isn't a tty **and** a display is set. |
+| **Commit signing** (`ssh-keygen -Y sign`) | No hook exists — `sign_one()` writes its notice with a bare `fprintf(stderr)` and git captures the signer's stderr, so nothing reaches your terminal at all. The wrapper alerts for the duration of the signing call instead. Verification and other subcommands pass through silently. |
+
+Notes and limits:
+
+- **Nothing about the threat model changes.** The alert cannot approve anything — presence is enforced in hardware. The askpass helper only ever receives the presence notice and refuses any other prompt rather than answering it; `SSH_ASKPASS_REQUIRE=force` is deliberately **not** set, so no passphrase prompt can ever be routed into it. The scripts live in `/nix/store` (immutable, hash-addressed).
+- **A muted Mac hears nothing** — the alert respects system volume.
+- **A warm `ControlMaster` needs no tap**, and correctly stays silent.
+- Not covered: browser WebAuthn taps (macOS shows its own dialog), `ssh-keygen -K` and the enrollment recipes, and Linux hosts (`lenovo-old` keeps the plain binaries).
+
+---
+
 ## Restore on a fresh / rebuilt machine
 
 The stub files are the only local state, and they're trivially regenerated from the YubiKey — **the actual key is in the hardware**. On a new machine (after `darwin-rebuild`/`nixos-rebuild`), plug in a YubiKey and run:
@@ -120,6 +151,7 @@ This deletes the old resident credential from the token (PIN required), generate
 
 - **`sign_and_send_pubkey: signing failed` / auth hangs** — the YubiKey isn't plugged in, or you didn't tap in time (the LED flashes for ~25s). Re-run and tap.
 - **`Key enrollment failed: invalid format` / `-sk` not recognized** — you're using Apple's `/usr/bin/ssh`. Ensure the Nix OpenSSH is first on PATH (`which ssh` should point into `/nix/store` or `~/.nix-profile`); the git config already pins it for git operations.
-- **Commits from Neovim / a GUI git client silently hang** — the tap prompt isn't visible in that UI; watch for the flashing YubiKey LED and tap. `commit.gpgsign = true` means *every* commit needs a tap.
+- **Commits from Neovim / a GUI git client silently hang** — the tap prompt isn't visible in that UI; listen for the touch alert (macOS) or watch for the flashing YubiKey LED, and tap. `commit.gpgsign = true` means *every* commit needs a tap.
+- **No touch alert on macOS** — check the system volume first, then `git config --get core.sshCommand` / `gpg.ssh.program`: both should point at a `yubikey-touch-*` wrapper in `/nix/store`. Verify with `just yubikey-test-sound`.
 - **`no FIDO2 PIN set` error from a recipe** — run `just yubikey-set-pin` first; resident-credential creation requires a PIN.
 - **`ykman: command not found`** — rebuild the host so home-manager installs `yubikey-manager`, or open a new shell to pick up the updated PATH.

--- a/docs/SSH.md
+++ b/docs/SSH.md
@@ -95,9 +95,12 @@ The two paths differ because OpenSSH treats them differently:
 
 Notes and limits:
 
-- **Nothing about the threat model changes.** The alert cannot approve anything — presence is enforced in hardware. The askpass helper only ever receives the presence notice and refuses any other prompt rather than answering it; `SSH_ASKPASS_REQUIRE=force` is deliberately **not** set, so no passphrase prompt can ever be routed into it. The scripts live in `/nix/store` (immutable, hash-addressed).
+- **The key stays unreachable.** The alert cannot approve anything — presence is enforced in hardware — and nothing here touches the token, the agent or any key material. `$SSH_ASKPASS` is a write-only channel from the helper's side: `notify_start()` forks it with stdin and stdout on `/dev/null` and only ever *passes* it a prompt string, so a compromised helper could supply a wrong answer but never read one.
+- **The helper can still see a real passphrase prompt**, so it guards on the prompt text and refuses anything that isn't the presence notice. `SSH_ASKPASS_REQUIRE=force` is deliberately **not** set — that would route prompts through the helper even when a tty is available — but setting `DISPLAY` is itself what sets `allow_askpass` in `readpass.c`, so whenever `open("/dev/tty")` fails (GUI git client, launchd, CI) `read_passphrase()` picks askpass on its own. The guard, not the absence of `force`, is what holds the line.
+- **Refusing is not entirely free.** A non-zero exit from the helper becomes `""` back in `read_passphrase()`. For a host-key confirmation that fails closed (`""` isn't `yes`). But `""` would also be an empty *PIN* — `sshsk_sign()` doesn't normalize it — and 8 consecutive wrong PINs wipe the applet. Today no PIN prompt exists (the credentials are user-presence-only). **Revisit this helper before enrolling any `-O verify-required` key.**
 - **A muted Mac hears nothing** — the alert respects system volume.
 - **A warm `ControlMaster` needs no tap**, and correctly stays silent.
+- **An orphaned alert stops itself.** Neither wrapper can guarantee cleanup — a SIGKILLed `ssh` never reaches `notify_complete()`, and a signal that skips the signing wrapper's `EXIT` trap leaves the loop running — so the beep exits on its own once its parent is gone or the touch window has closed.
 - Not covered: browser WebAuthn taps (macOS shows its own dialog), `ssh-keygen -K` and the enrollment recipes, and Linux hosts (`lenovo-old` keeps the plain binaries).
 
 ---

--- a/just/ssh.just
+++ b/just/ssh.just
@@ -221,3 +221,26 @@ rotate-ssh-key which:
     echo "=========================================================================="
     echo "Then delete the old entries at https://github.com/settings/keys"
     echo "Note: deleting a Signing key flips its past commits to Unverified (recomputed live)."
+
+# Verify the audible touch alert on both paths: SSH auth and commit signing.
+yubikey-test-sound:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "$(uname -s)" != "Darwin" ]; then
+      echo "The touch alert is macOS-only (uses /usr/bin/afplay)." >&2
+      exit 1
+    fi
+    SSH_CMD=$(git config --get core.sshCommand)
+    SIGN_CMD=$(git config --get gpg.ssh.program)
+    echo "── 1/2  SSH auth ───────────────────────────────────"
+    echo "Contacting github.com — the alert should sound until you tap, then stop."
+    # ControlPath=none forces a fresh connection: a warm ControlMaster needs no
+    # tap, and correctly stays silent.
+    $SSH_CMD -o ControlPath=none -T git@github.com || true
+    echo ""
+    echo "── 2/2  Commit signing ─────────────────────────────"
+    echo "Signing a test payload — the alert should sound until you tap, then stop."
+    printf 'yubikey-test-sound' | \
+      $SIGN_CMD -Y sign -n test -f "$HOME/.ssh/id_ed25519_sk.pub" - >/dev/null
+    echo ""
+    echo "✓ Both paths alerted. If you heard nothing, check the system volume."

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -1,9 +1,22 @@
 {
+  root,
   pkgs,
   lib,
   userConfig,
   ...
 }:
+let
+  # macOS-only: make the YubiKey touch request audible, since the LED is
+  # unreadable in bright light. Linux keeps the plain OpenSSH binaries.
+  touchSound = import "${root}/programs/yubikey-touch-sound" { inherit pkgs lib; };
+
+  sshCommand = if pkgs.stdenv.isDarwin then lib.getExe touchSound.ssh else lib.getExe pkgs.openssh;
+  sshKeygenCommand =
+    if pkgs.stdenv.isDarwin then
+      lib.getExe touchSound.sshKeygen
+    else
+      lib.getExe' pkgs.openssh "ssh-keygen";
+in
 {
   home.packages = with pkgs; [
     pre-commit
@@ -31,9 +44,11 @@
 
       # Force the FIDO-capable Nix OpenSSH for both transport and signing. Without
       # this, git (or a GUI client) could fall back to macOS's /usr/bin/ssh, which
-      # cannot use ed25519-sk keys and would break auth + signing.
-      core.sshCommand = lib.getExe pkgs.openssh;
-      gpg.ssh.program = lib.getExe' pkgs.openssh "ssh-keygen";
+      # cannot use ed25519-sk keys and would break auth + signing. On macOS both
+      # go through thin wrappers that sound an alert while the token waits for a
+      # tap — see programs/yubikey-touch-sound.
+      core.sshCommand = sshCommand;
+      gpg.ssh.program = sshKeygenCommand;
 
       # Sign commits and tags with SSH by default (GitHub shows a "Verified" badge).
       gpg.format = "ssh";

--- a/modules/home/ssh.nix
+++ b/modules/home/ssh.nix
@@ -24,8 +24,10 @@
         ];
         IdentitiesOnly = true; # only offer these keys, never spray other agent keys at GitHub
 
-        # Connection multiplexing. A verify-required ed25519-sk key re-runs the
-        # full YubiKey ceremony (touch + PIN) on *every* SSH session, and a single
+        # Connection multiplexing. An ed25519-sk key demands a fresh physical tap
+        # on *every* SSH session (the credential is enrolled user-presence-only,
+        # sk_flags 0x21 — the FIDO2 PIN gates enrollment and extraction, not
+        # per-signature use), and a single
         # `git push` on an LFS repo opens several (git-lfs-authenticate, the
         # receive-pack push, LFS transfers) within seconds of each other. Share one
         # authenticated master so the ceremony happens once per push.

--- a/programs/yubikey-touch-sound/default.nix
+++ b/programs/yubikey-touch-sound/default.nix
@@ -152,8 +152,6 @@ let
 in
 {
   inherit
-    beep
-    askpass
     ssh
     sshKeygen
     ;

--- a/programs/yubikey-touch-sound/default.nix
+++ b/programs/yubikey-touch-sound/default.nix
@@ -1,0 +1,160 @@
+# Audible alert while the YubiKey is waiting for a physical touch (macOS).
+#
+# The LED is invisible in bright light, so a tap-required operation just hangs
+# with no usable feedback. These wrappers make the Mac play a sound for as long
+# as the token is waiting, and stop the instant you tap.
+#
+# Only Apple-shipped software does the talking: /usr/bin/afplay and a stock
+# /System/Library/Sounds/*.aiff. No daemon, no agent, no third-party package.
+#
+# There are two touch paths and they need different treatment:
+#
+#   * SSH auth (`git push`, `ssh`) — OpenSSH has a first-class hook here:
+#     sshconnect2.c:identity_sign() calls notify_start(), which forks
+#     $SSH_ASKPASS with the notification as argv[1] and SIGTERMs it the moment
+#     the touch lands (readpass.c). Exact timing, self-stopping. See `ssh`.
+#
+#   * Commit signing (`ssh-keygen -Y sign`) — no hook exists: sign_one() writes
+#     "Confirm user presence..." with a bare fprintf(stderr) and git captures
+#     the signer's stderr, so today nothing whatsoever reaches the terminal.
+#     Handled by beeping for the duration of the call. See `sshKeygen`.
+{
+  pkgs,
+  lib ? pkgs.lib,
+  # Any stock macOS system sound. Hero is the loudest of them (-24 dBFS RMS,
+  # 0.54 peak — roughly 5 dB above Submarine and on par with herdr's chime).
+  sound ? "/System/Library/Sounds/Hero.aiff",
+  # afplay gain. 1.0 is the file as-is; higher amplifies past the system volume,
+  # which is the point — this has to cut through outdoor noise.
+  volume ? "6",
+  # Gap between repeats, in seconds.
+  interval ? "0.7",
+}:
+
+let
+  afplay = "/usr/bin/afplay";
+  openssh = lib.getExe pkgs.openssh;
+  opensshKeygen = lib.getExe' pkgs.openssh "ssh-keygen";
+
+  # Repeats the alert until killed. Kept in its own script so both entry points
+  # share one implementation.
+  beep = pkgs.writeShellApplication {
+    name = "yubikey-touch-beep";
+    text = ''
+      child=""
+
+      # Take the in-flight afplay down with us instead of letting it finish.
+      # Never `kill 0`: this process shares its process group with ssh (and
+      # therefore with git and the shell's foreground job).
+      cleanup() {
+        if [ -n "$child" ]; then
+          kill "$child" 2>/dev/null || true
+        fi
+        exit 0
+      }
+      trap cleanup TERM INT
+
+      while :; do
+        ${afplay} -v ${volume} ${sound} >/dev/null 2>&1 &
+        child=$!
+        wait "$child" || true
+
+        sleep ${interval} &
+        child=$!
+        wait "$child" || true
+      done
+    '';
+  };
+
+  # $SSH_ASKPASS target. ssh(1) execs this with the notification text as $1,
+  # stdin and stdout on /dev/null, and SIGTERMs it once the touch completes.
+  askpass = pkgs.writeShellApplication {
+    name = "yubikey-touch-askpass";
+    text = ''
+      # This must never behave like a passphrase reader. Our credentials are
+      # touch-only (sk_flags 0x21: user-presence + resident, no
+      # user-verification), so the presence notification is the only prompt
+      # that can legitimately reach us. Refuse anything else loudly rather than
+      # answering it with an empty line, which ssh would take as a passphrase.
+      case "''${1-}" in
+      "Confirm user presence"*) ;;
+      *)
+        echo "yubikey-touch-askpass: refusing unexpected prompt: ''${1-<empty>}" >&2
+        exit 1
+        ;;
+      esac
+
+      # ssh took the askpass branch, so it did not print the notice itself.
+      echo "$1" >&2
+
+      exec ${lib.getExe beep}
+    '';
+  };
+
+  # Drop-in ssh for git (core.sshCommand) that turns the touch request audible.
+  #
+  # notify_start() only uses $SSH_ASKPASS when stderr is NOT a tty (or BatchMode
+  # is on) AND DISPLAY/WAYLAND_DISPLAY is set. Hence the two adjustments below.
+  # We deliberately do NOT set SSH_ASKPASS_REQUIRE=force, which would also route
+  # passphrase prompts through the helper.
+  ssh = pkgs.writeShellApplication {
+    name = "yubikey-touch-ssh";
+    text = ''
+      export SSH_ASKPASS=${lib.getExe askpass}
+      # macOS has no X server; ssh only consults DISPLAY for X11 forwarding,
+      # which is off. A real value (XQuartz) wins if one is already set.
+      export DISPLAY="''${DISPLAY:-:0}"
+
+      # Run ssh with stderr on a pipe so isatty(STDERR_FILENO) is false, while
+      # still delivering that stderr to the terminal. stdout and stdin are
+      # untouched: git owns those.
+      exec 3>&1
+      set +e
+      { ${openssh} "$@" 2>&1 1>&3 3>&-; } | cat >&2
+      rc=''${PIPESTATUS[0]}
+      set -e
+      exit "$rc"
+    '';
+  };
+
+  # Drop-in ssh-keygen for git (gpg.ssh.program). Signing always needs a tap and
+  # has no notifier hook, so alert for the whole call. Verification and every
+  # other subcommand are passed straight through, untouched and silent.
+  sshKeygen = pkgs.writeShellApplication {
+    name = "yubikey-touch-ssh-keygen";
+    text = ''
+      signing=0
+      prev=""
+      for arg in "$@"; do
+        if [ "$prev" = "-Y" ] && [ "$arg" = "sign" ]; then
+          signing=1
+          break
+        fi
+        prev="$arg"
+      done
+
+      if [ "$signing" -eq 0 ]; then
+        exec ${opensshKeygen} "$@"
+      fi
+
+      # stdout carries the signature back to git — keep the alert off it.
+      ${lib.getExe beep} >/dev/null 2>&1 &
+      loop=$!
+      trap 'kill "$loop" 2>/dev/null || true' EXIT
+
+      set +e
+      ${opensshKeygen} "$@"
+      rc=$?
+      set -e
+      exit "$rc"
+    '';
+  };
+in
+{
+  inherit
+    beep
+    askpass
+    ssh
+    sshKeygen
+    ;
+}

--- a/programs/yubikey-touch-sound/default.nix
+++ b/programs/yubikey-touch-sound/default.nix
@@ -29,6 +29,10 @@
   volume ? "6",
   # Gap between repeats, in seconds.
   interval ? "0.7",
+  # Hard ceiling on a single alert, in seconds. Matches the ~25s touch window
+  # the LED flashes for: past that the operation has failed anyway, so a still-
+  # sounding alert can only mean it was orphaned. See `beep`.
+  timeoutSeconds ? "30",
 }:
 
 let
@@ -40,7 +44,12 @@ let
   # share one implementation.
   beep = pkgs.writeShellApplication {
     name = "yubikey-touch-beep";
+    # `sleep`. Without this, writeShellApplication leaves PATH as the caller's,
+    # so a shadowed `sleep` would run inside the auth path.
+    runtimeInputs = [ pkgs.coreutils ];
     text = ''
+      parent=$PPID
+      deadline=$(( SECONDS + ${timeoutSeconds} ))
       child=""
 
       # Take the in-flight afplay down with us instead of letting it finish.
@@ -52,16 +61,26 @@ let
         fi
         exit 0
       }
-      trap cleanup TERM INT
+      trap cleanup TERM INT HUP
 
-      while :; do
+      # Nothing outside can be relied on to stop us. A SIGKILLed ssh never
+      # reaches notify_complete(), and a SIGKILLed or SIGTERMed signing wrapper
+      # never runs its EXIT trap — either way this process is orphaned and
+      # would beep until logout. No trap can cover SIGKILL, so police
+      # ourselves: stop once the parent is gone, and in any case once the touch
+      # window has closed.
+      while [ "$SECONDS" -lt "$deadline" ]; do
+        kill -0 "$parent" 2>/dev/null || exit 0
+
         ${afplay} -v ${volume} ${sound} >/dev/null 2>&1 &
         child=$!
         wait "$child" || true
+        child="" # reaped — the PID can be recycled, so never kill it again
 
         sleep ${interval} &
         child=$!
         wait "$child" || true
+        child=""
       done
     '';
   };
@@ -71,11 +90,6 @@ let
   askpass = pkgs.writeShellApplication {
     name = "yubikey-touch-askpass";
     text = ''
-      # This must never behave like a passphrase reader. Our credentials are
-      # touch-only (sk_flags 0x21: user-presence + resident, no
-      # user-verification), so the presence notification is the only prompt
-      # that can legitimately reach us. Refuse anything else loudly rather than
-      # answering it with an empty line, which ssh would take as a passphrase.
       case "''${1-}" in
       "Confirm user presence"*) ;;
       *)
@@ -95,10 +109,15 @@ let
   #
   # notify_start() only uses $SSH_ASKPASS when stderr is NOT a tty (or BatchMode
   # is on) AND DISPLAY/WAYLAND_DISPLAY is set. Hence the two adjustments below.
-  # We deliberately do NOT set SSH_ASKPASS_REQUIRE=force, which would also route
-  # passphrase prompts through the helper.
+  # We deliberately do NOT set SSH_ASKPASS_REQUIRE=force, which would route
+  # passphrase prompts through the helper even when a tty is available. Setting
+  # DISPLAY still opens that door for the no-tty case, which is why the helper
+  # guards on the prompt text.
   ssh = pkgs.writeShellApplication {
     name = "yubikey-touch-ssh";
+    # `cat`. Without this, writeShellApplication leaves PATH as the caller's,
+    # so a shadowed `cat` would run inside the auth path.
+    runtimeInputs = [ pkgs.coreutils ];
     text = ''
       export SSH_ASKPASS=${lib.getExe askpass}
       # macOS has no X server; ssh only consults DISPLAY for X11 forwarding,
@@ -137,9 +156,11 @@ let
         exec ${opensshKeygen} "$@"
       fi
 
-      # stdout carries the signature back to git — keep the alert off it.
-      ${lib.getExe beep} >/dev/null 2>&1 &
+      # stdout carries the signature back to git — keep the alert off it, and
+      # off stdin too, which is the pipe git streams the payload down.
+      ${lib.getExe beep} </dev/null >/dev/null 2>&1 &
       loop=$!
+      # Best-effort: an untrapped signal skips this, so beep also stops itself.
       trap 'kill "$loop" 2>/dev/null || true' EXIT
 
       set +e


### PR DESCRIPTION
The LED is unreadable in bright light, so a tap-required operation just hangs with no usable feedback and commands time out. Play a stock macOS system sound on a loop while the token waits, stopping the moment you tap.

Only Apple software makes the noise: /usr/bin/afplay and /System/Library/Sounds/Submarine.aiff. No daemon, no agent, no third-party package, and no change to the threat model — the alert cannot approve anything, presence is still enforced in hardware.

The two touch paths need different treatment:

  * SSH auth (git push, ssh) uses OpenSSH's own notifier: notify_start() forks $SSH_ASKPASS when a tap is needed and SIGTERMs it once the tap lands. It only does so when stderr is not a tty and DISPLAY is set, hence the pipe and the placeholder DISPLAY in the ssh wrapper. SSH_ASKPASS_REQUIRE=force is deliberately not set: it would also route passphrase prompts into the helper. The helper refuses any prompt that is not the presence notification rather than answering it.

  * Commit signing (ssh-keygen -Y sign) has no hook at all: sign_one() writes its notice with a bare fprintf(stderr) and git captures the signer's stderr, so nothing reached the terminal. That wrapper alerts for the duration of the signing call; verification and every other subcommand pass through untouched and silent.

Also corrects a stale comment in ssh.nix: these credentials are enrolled user-presence-only (sk_flags 0x21), so the FIDO2 PIN gates enrollment and extraction, not per-signature use — there is no PIN prompt per push.