### PR TITLE
Rust typos spell-checker (NeoVim + CLI)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,21 @@
+# Committed spell-check allowlist for this repo — the only layer CI sees.
+#
+# Words that must not be disclosed go in the private global allowlist instead
+# (~/.config/typos/typos.toml); see programs/typos. Everything here is safe to
+# publish, which is why it lives in git where `nix flake check` can reach it.
+
+[files]
+# SOPS ciphertext. The false positive (`Iy` -> `It`) sits inside base64, and the
+# letters are reshuffled on every re-encrypt, so allowlisting the word would both
+# break at the next rotation and blind us to a real `Iy` in prose.
+extend-exclude = ["secrets/secrets.yaml"]
+
+[default.extend-words]
+# The nvim-noice plugin. Lowercase covers `Noice` and `NoiceDismiss` too, since
+# matching is case-insensitive and happens after identifiers are split.
+noice = "noice"
+
+# Half of the `<leader>nd` keybinding in programs/nvim/core/theme.nix, not a word.
+# Scoped to this repo on purpose: allowing `nd` globally would hide a genuine
+# `nd` -> `and` in prose everywhere, forever.
+nd = "nd"

--- a/Justfile
+++ b/Justfile
@@ -20,8 +20,30 @@ lint:
 format *ARGS:
     nix fmt -- {{ ARGS }}
 
-# Run all checks (lint + format + flake check)
+# Spell check (typos). `--inputs-from .` resolves nixpkgs through flake.lock, so
+# this is the same build the `typos` flake check runs in CI. Runs unwrapped, so
+# it sees only the committed .typos.toml — exactly what CI sees.
+typos *ARGS:
+    nix run --inputs-from . nixpkgs#typos -- {{ ARGS }}
+
+# Edit the private global typos allowlist. Not committed anywhere — it holds
+# words that must not be disclosed, which is why it is seeded once by home
+# activation and left unmanaged. Path mirrors programs/typos (source of truth).
+# Already-running Neovim instances keep the old list until their typos_lsp
+# restarts; <leader>ad does that automatically, editing by hand does not.
+typos-edit:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    allowlist="$HOME/.config/typos/typos.toml"
+    if [ ! -e "$allowlist" ]; then
+        echo "No global allowlist yet — run darwin-rebuild switch to seed it." >&2
+        exit 1
+    fi
+    nvim "$allowlist"
+
+# Run all checks (lint + format + spell + flake check)
 check:
     just lint
     just format --ci
+    just typos
     nix flake check

--- a/Justfile
+++ b/Justfile
@@ -20,17 +20,21 @@ lint:
 format *ARGS:
     nix fmt -- {{ ARGS }}
 
-# Spell check (typos). `--inputs-from .` resolves nixpkgs through flake.lock, so
-# this is the same build the `typos` flake check runs in CI. Runs unwrapped, so
-# it sees only the committed .typos.toml — exactly what CI sees.
+# `--inputs-from .` resolves nixpkgs through flake.lock, so this is the same
+# build the `typos` flake check runs in CI. Runs unwrapped, so it sees only the
+# committed .typos.toml — never the private global allowlist, exactly like CI.
+#
+# Spell check all files (pinned to flake.lock; identical to CI)
 typos *ARGS:
     nix run --inputs-from . nixpkgs#typos -- {{ ARGS }}
 
-# Edit the private global typos allowlist. Not committed anywhere — it holds
-# words that must not be disclosed, which is why it is seeded once by home
-# activation and left unmanaged. Path mirrors programs/typos (source of truth).
-# Already-running Neovim instances keep the old list until their typos_lsp
-# restarts; <leader>ad does that automatically, editing by hand does not.
+# Holds words that must not be disclosed, so it is committed nowhere — seeded
+# once by home activation, then left unmanaged. Path mirrors programs/typos,
+# which is the source of truth. Note that already-running Neovim instances keep
+# the old list until their typos_lsp restarts: <leader>ad does that for you,
+# editing by hand does not.
+#
+# Edit the private global typos allowlist in Neovim
 typos-edit:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/docs/adr/0001-typos-two-layer-allowlist.md
+++ b/docs/adr/0001-typos-two-layer-allowlist.md
@@ -1,0 +1,61 @@
+# Two-layer typos allowlist, one layer deliberately unmanaged
+
+`typos` runs on three surfaces (CLI, Neovim LSP, CI gate) and needs somewhere to
+record false positives. Because **this repo is public**, false positives hit while
+working in private repos — client names, internal codenames — cannot be committed
+here. So there are two layers: a committed `.typos.toml` per project, and a
+mutable, untracked `~/.config/typos/typos.toml` for words whose disclosure
+matters. The private layer is intentionally **not** Home Manager managed, which is
+a deliberate deviation from this repo's declarative-by-default rule.
+
+## Why the private layer can't be Nix-managed
+
+Two independent reasons, either one sufficient:
+
+1. **Disclosure.** A store-built config would have to be generated from something
+   committed to this public repo — the exact thing the layer exists to avoid.
+2. **Mutability.** The `<leader>ad` keymap appends the flagged word to the
+   allowlist. A read-only store path cannot be appended to.
+
+Home Manager therefore *seeds* the file when it is absent and never touches it
+again. This is a one-time seed, not a managed value: later improvements to the
+seed in this repo do not reach already-provisioned machines.
+
+## Why `--config` and not a file in `$HOME`
+
+typos' ancestor walk stops at the first config it finds:
+
+```rust
+if !self.isolated {
+    for ancestor in cwd.ancestors() {
+        if let Some(derived) = Config::from_dir(ancestor)? {
+            config.update(&derived);
+            break;
+        }
+    }
+}
+```
+
+The walk ignores VCS roots and runs all the way to `/`, so a `~/typos.toml` *would*
+be discovered — but only for projects that have no config of their own. It would
+appear to work and then silently stop the moment a project grew a `.typos.toml`,
+including this one. The explicit `--config` / `init_options.config` channel is the
+only mechanism that genuinely layers: it loads into typos' *override* layer, where
+`extend-words` from both layers merge.
+
+## Consequences
+
+- **Accepted local/CI divergence.** The private layer is invisible to CI by
+  design, so a globally allowed word can make a local run pass while CI fails.
+  `just typos` runs unwrapped against the same pinned build CI uses, which is the
+  intended way to catch this before pushing.
+- **The global `extend-exclude` is the sharper edge of that.** It can hide a whole
+  file locally that CI still scans, so it is kept to machine-generated and
+  encoded content only (`*.lock`, `*.age`, `secrets/**`).
+- **No backup.** The private allowlist is the one piece of machine state that is
+  untracked and unbacked-up. Encrypting it with the repo's existing SOPS setup was
+  considered and rejected: it would return the file to the store, immutable, and
+  break `<leader>ad` entirely.
+- **typos is pinned** to the locked nixpkgs in both the flake check and `just
+  typos`, because its dictionary grows every release and a floating version could
+  turn CI red with no change to the repo.

--- a/docs/adr/0001-typos-two-layer-allowlist.md
+++ b/docs/adr/0001-typos-two-layer-allowlist.md
@@ -19,7 +19,8 @@ Two independent reasons, either one sufficient:
 
 Home Manager therefore *seeds* the file when it is absent and never touches it
 again. This is a one-time seed, not a managed value: later improvements to the
-seed in this repo do not reach already-provisioned machines.
+seed in this repo do not reach already-provisioned machines. After that it is
+edited only by hand — `<leader>ad` from a typo in Neovim, or `just typos-edit`.
 
 ## Why `--config` and not a file in `$HOME`
 
@@ -58,4 +59,6 @@ only mechanism that genuinely layers: it loads into typos' *override* layer, whe
   break `<leader>ad` entirely.
 - **typos is pinned** to the locked nixpkgs in both the flake check and `just
   typos`, because its dictionary grows every release and a floating version could
-  turn CI red with no change to the repo.
+  turn CI red with no change to the repo. The corollary is that bumping
+  `flake.lock` *can* legitimately surface new findings: that is the pin working as
+  intended, and the fix is to allowlist the words, not to unpin typos.

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,12 @@
             inherit inputs pkgs;
             root = self;
           }).check;
+
+        # Spell check. Pinned to the locked nixpkgs deliberately: typos' dictionary
+        # is its product and grows with every release, so a floating version could
+        # turn CI red with no change to this repo. Sees only the committed
+        # `.typos.toml`, never the private global allowlist.
+        typos = (import ./programs/typos { inherit pkgs; }).mkCheck self;
       });
 
       devShells = lib.forAllSystems (pkgs: {

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -7,6 +7,7 @@
     ./bitwarden.nix
     ./git.nix
     ./ssh.nix
+    ./typos.nix
     ./languages/typescript.nix
     ./languages/haskell.nix
     ./languages/nix.nix

--- a/modules/home/nvim.nix
+++ b/modules/home/nvim.nix
@@ -2,9 +2,12 @@
   root,
   themeConfig,
   pkgs,
+  lib,
   ...
 }:
 let
+  typos = import "${root}/programs/typos" { inherit pkgs lib; };
+
   nvimStyle =
     {
       dark = "catppuccin_dark";
@@ -23,6 +26,9 @@ in
     myNixVim.style = nvimStyle;
     imports = [
       (import "${root}/programs/nvim")
+      # Shared with modules/home/typos.nix so the allowlist path has one source
+      # of truth; nixvim modules don't get `root`, so it has to be passed in.
+      { _module.args.typos = typos; }
     ];
   };
 }

--- a/modules/home/nvim.nix
+++ b/modules/home/nvim.nix
@@ -2,12 +2,9 @@
   root,
   themeConfig,
   pkgs,
-  lib,
   ...
 }:
 let
-  typos = import "${root}/programs/typos" { inherit pkgs lib; };
-
   nvimStyle =
     {
       dark = "catppuccin_dark";
@@ -26,9 +23,11 @@ in
     myNixVim.style = nvimStyle;
     imports = [
       (import "${root}/programs/nvim")
-      # Shared with modules/home/typos.nix so the allowlist path has one source
-      # of truth; nixvim modules don't get `root`, so it has to be passed in.
-      { _module.args.typos = typos; }
+      # nixvim evaluates its own module tree, so this repo's `root` special arg
+      # does not carry into it. The dev shells supply it via
+      # makeNixvimWithModule's `extraSpecialArgs`; nixvim's Home Manager wrapper
+      # has no equivalent passthrough, so declare it directly.
+      { _module.args.root = root; }
     ];
   };
 }

--- a/modules/home/typos.nix
+++ b/modules/home/typos.nix
@@ -1,0 +1,27 @@
+{
+  root,
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  typos = import "${root}/programs/typos" { inherit pkgs lib; };
+in
+{
+  home.packages = [ typos.cli ];
+
+  # The global allowlist is intentionally NOT Home Manager managed. It holds words
+  # that must not be committed to this public repo, and <leader>ad has to be able
+  # to append to it — both rule out a read-only store path. Seed it once when it
+  # is missing, then never touch it again. See programs/typos for the full
+  # rationale.
+  home.activation.typosGlobalAllowlist = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    typosAllowlist="${config.home.homeDirectory}/${typos.globalConfigRelPath}"
+    if [ ! -e "$typosAllowlist" ]; then
+      run mkdir -p "$(dirname "$typosAllowlist")"
+      # 0600: this file is expected to accumulate words from private work.
+      run install -m 0600 ${typos.seed} "$typosAllowlist"
+    fi
+  '';
+}

--- a/programs/nvim/core/typos.nix
+++ b/programs/nvim/core/typos.nix
@@ -1,0 +1,165 @@
+{ pkgs, typos, ... }:
+
+{
+  plugins.lsp.servers.typos_lsp = {
+    enable = true;
+    # Baked in for the same reason as nil_ls: typos is not language-specific, so
+    # no project dev shell would ever put this binary on PATH.
+    package = pkgs.typos-lsp;
+
+    extraOptions.init_options = {
+      # Layered on top of whatever `.typos.toml` the workspace provides — the
+      # editor equivalent of the CLI's `--config`. See programs/typos.
+      config = typos.globalConfigPath;
+
+      # Subordinate to real LSP diagnostics. typos is always-on across every file
+      # that gets opened; at the default "Info" it crowds out actual errors in the
+      # <leader>e float and the sign column.
+      diagnosticSeverity = "Warning";
+    };
+  };
+
+  keymaps = [
+    {
+      mode = "n";
+      key = "<leader>ad";
+      action = "<cmd>lua TyposAddWord()<CR>";
+      options.desc = "Add word to typos allowlist";
+    }
+  ];
+
+  extraConfigLua = ''
+    -- Add the typo under the cursor to an allowlist. Two destinations, because
+    -- this nixos repo is public: see programs/typos for why.
+    local TYPOS_GLOBAL_ALLOWLIST = vim.fn.expand("${typos.globalConfigPath}")
+
+    local function typos_client()
+      return vim.lsp.get_clients({ bufnr = 0, name = "typos_lsp" })[1]
+    end
+
+    -- The exact token typos flagged, or nil.
+    --
+    -- Reads the diagnostic rather than <cword> deliberately. `extend-words` is
+    -- matched *after* identifiers are split, so with the cursor in `NoiceDismiss`
+    -- the flagged token is `Noice`; writing `noicedismiss` would match nothing at
+    -- all and fail silently.
+    local function flagged_word()
+      local client = typos_client()
+      if not client then
+        return nil
+      end
+
+      local pos = vim.api.nvim_win_get_cursor(0)
+      local lnum, col = pos[1] - 1, pos[2]
+
+      -- Scope to typos' own namespace so a diagnostic from another server on the
+      -- same line is never picked up by mistake.
+      local opts = { lnum = lnum }
+      local ok, ns = pcall(vim.lsp.diagnostic.get_namespace, client.id)
+      if ok then
+        opts.namespace = ns
+      end
+
+      for _, d in ipairs(vim.diagnostic.get(0, opts)) do
+        if d.lnum == lnum and col >= d.col and col < d.end_col then
+          return vim.api.nvim_buf_get_text(0, d.lnum, d.col, d.end_lnum, d.end_col, {})[1]
+        end
+      end
+      return nil
+    end
+
+    -- Insert `word = "word"` under [default.extend-words], creating the table (or
+    -- the whole file) when absent. Returns false if the word is already listed.
+    local function allow_word(path, word)
+      local lines = vim.fn.filereadable(path) == 1 and vim.fn.readfile(path) or {}
+      local pattern = "^%s*" .. vim.pesc(word) .. "%s*="
+
+      for _, line in ipairs(lines) do
+        if line:match(pattern) then
+          return false
+        end
+      end
+
+      local header
+      for i, line in ipairs(lines) do
+        if line:match("^%s*%[default%.extend%-words%]%s*$") then
+          header = i
+          break
+        end
+      end
+
+      local entry = string.format('%s = "%s"', word, word)
+      if header then
+        table.insert(lines, header + 1, entry)
+      else
+        if #lines > 0 and lines[#lines] ~= "" then
+          table.insert(lines, "")
+        end
+        table.insert(lines, "[default.extend-words]")
+        table.insert(lines, entry)
+      end
+
+      vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+      vim.fn.writefile(lines, path)
+      return true
+    end
+
+    -- typos-lsp does not watch its config files: "Restart the server after
+    -- changing either the workspace config file or the explicit custom config
+    -- file for the new changes to take effect." Without this the word appears to
+    -- have no effect at all.
+    local function restart_typos()
+      vim.lsp.enable("typos_lsp", false)
+      vim.schedule(function()
+        vim.lsp.enable("typos_lsp", true)
+      end)
+    end
+
+    local function project_allowlist()
+      local client = typos_client()
+      local root = (client and client.root_dir) or vim.fn.getcwd()
+      return root .. "/.typos.toml"
+    end
+
+    function TyposAddWord()
+      local word = flagged_word()
+      if not word then
+        vim.notify("typos: no typo under the cursor", vim.log.levels.WARN)
+        return
+      end
+
+      -- Lowercase: matching is case-insensitive, so one entry covers every casing.
+      word = word:lower()
+
+      local destinations = {
+        { label = "Global (private, never committed)", path = TYPOS_GLOBAL_ALLOWLIST },
+        { label = "This project (.typos.toml, committed)", path = project_allowlist() },
+      }
+
+      vim.ui.select(destinations, {
+        prompt = string.format("Allow '%s' in:", word),
+        format_item = function(item)
+          return item.label
+        end,
+      }, function(choice)
+        if not choice then
+          return
+        end
+
+        local ok, added = pcall(allow_word, choice.path, word)
+        if not ok then
+          vim.notify("typos: " .. tostring(added), vim.log.levels.ERROR)
+          return
+        end
+
+        if not added then
+          vim.notify(string.format("typos: '%s' is already allowed in %s", word, choice.path))
+          return
+        end
+
+        vim.notify(string.format("typos: allowed '%s' in %s", word, choice.path))
+        restart_typos()
+      end)
+    end
+  '';
+}

--- a/programs/nvim/core/typos.nix
+++ b/programs/nvim/core/typos.nix
@@ -1,5 +1,8 @@
-{ pkgs, typos, ... }:
+{ pkgs, root, ... }:
 
+let
+  typos = import "${root}/programs/typos" { inherit pkgs; };
+in
 {
   plugins.lsp.servers.typos_lsp = {
     enable = true;
@@ -12,9 +15,9 @@
       # editor equivalent of the CLI's `--config`. See programs/typos.
       config = typos.globalConfigPath;
 
-      # Subordinate to real LSP diagnostics. typos is always-on across every file
-      # that gets opened; at the default "Info" it crowds out actual errors in the
-      # <leader>e float and the sign column.
+      # Neovim renders diagnostics as an underline plus a sign and nothing else
+      # (`virtual_text` defaults to false), so anything below Warning is easy to
+      # miss entirely — a Hint is a faint underline with no message anywhere.
       diagnosticSeverity = "Warning";
     };
   };

--- a/programs/nvim/default.nix
+++ b/programs/nvim/default.nix
@@ -13,6 +13,7 @@
     ./core/clipboard.nix
     ./core/context-aware-keymaps.nix
     ./core/scrolling.nix
+    ./core/typos.nix
     ./languages/nix.nix
     ./languages/mdc.nix
     ./languages/typescript.nix

--- a/programs/typos/default.nix
+++ b/programs/typos/default.nix
@@ -1,0 +1,115 @@
+# Source-code spell checking — https://github.com/crate-ci/typos
+#
+# typos only flags *known* misspellings rather than unknown words, which is what
+# makes it tolerable as an always-on editor diagnostic. The false positives it
+# does produce are mostly tool names that collide with real misspellings
+# (`noice` -> `noise`) and short tokens in non-prose contexts.
+#
+# There are two allowlist layers, and the split is about disclosure, not scope:
+#
+#   * a committed `.typos.toml` per project — shared, reviewable, and the only
+#     layer CI ever sees.
+#   * `~/.config/typos/typos.toml` — mutable, untracked, for words that must not
+#     be disclosed (client names, internal codenames encountered while working in
+#     private repos). This nixos repo is public, so a Nix-built config is not an
+#     option: it would have to be generated from something committed here, which
+#     is the exact thing the layer exists to avoid. It is also the only shape the
+#     `<leader>ad` keymap can append to.
+#
+# The layers genuinely compose. `--config` is loaded into typos' *override* layer
+# rather than replacing discovery (typos-cli/src/bin/typos-cli/main.rs), and
+# `update()` extends collections, so `extend-words` from both layers merge.
+#
+# That explicit channel is also the *only* mechanism that works. typos' ancestor
+# walk breaks at the first config it finds:
+#
+#     if !self.isolated {
+#         for ancestor in cwd.ancestors() {
+#             if let Some(derived) = Config::from_dir(ancestor)? {
+#                 config.update(&derived);
+#                 break;
+#             }
+#         }
+#     }                                        -- typos-cli/src/policy.rs
+#
+# so simply dropping a file in $HOME would appear to work and then silently stop
+# the moment a project grew a `.typos.toml` of its own.
+{
+  pkgs,
+  lib ? pkgs.lib,
+  # Where the mutable global allowlist lives, relative to $HOME. Deliberately
+  # kept out of the ancestor-walk path: it must only ever apply when passed
+  # explicitly, never by accidental discovery from a nearby directory.
+  globalConfigRelPath ? ".config/typos/typos.toml",
+}:
+let
+  typos = lib.getExe' pkgs.typos "typos";
+in
+{
+  inherit globalConfigRelPath;
+
+  # `~`-relative form, for consumers that expand it themselves (typos-lsp does).
+  globalConfigPath = "~/${globalConfigRelPath}";
+
+  # Written once by home activation, only when the file is absent. Because the
+  # file is user-owned and never overwritten, this is a one-time seed rather than
+  # a managed value: later changes here do not reach already-provisioned machines.
+  seed = pkgs.writeText "typos-global-allowlist.toml" ''
+    # Mutable, untracked global typos allowlist.
+    #
+    # Seeded once by Home Manager and never overwritten, so hand edits are safe —
+    # but improvements to the seed in the nixos repo will not reach this file.
+    # Add words from Neovim with <leader>ad, or edit it directly.
+    #
+    # Only put words here that must NOT be committed to a public repo — client
+    # names, internal codenames. Anything shareable belongs in the project's own
+    # .typos.toml, where CI and teammates can see it.
+    #
+    # Keys map a word to itself to mark it valid. Matching is case-insensitive and
+    # happens after identifiers are split, so one lowercase entry covers every
+    # casing and every identifier the word appears inside.
+
+    [files]
+    # Machine-generated or encoded content is never meaningfully spell-checkable,
+    # and regenerating it reshuffles the letters — word entries would not survive
+    # the next rotation, so these have to be excluded by path.
+    extend-exclude = [
+      "*.lock",
+      "*.age",
+      "*.enc.*",
+      "secrets/**",
+    ]
+
+    [default.extend-words]
+  '';
+
+  # `typos` for $PATH, carrying the global layer.
+  #
+  # The existence check is load-bearing: typos exits 78 (EX_CONFIG) on *every*
+  # invocation when --config points at a missing file, so a deleted allowlist has
+  # to degrade to plain typos rather than break the command outright.
+  cli = pkgs.writeShellApplication {
+    name = "typos";
+    text = ''
+      config="$HOME/${globalConfigRelPath}"
+      if [ -f "$config" ]; then
+        exec ${typos} --config "$config" "$@"
+      fi
+      exec ${typos} "$@"
+    '';
+  };
+
+  # The `nix flake check` gate.
+  #
+  # Pinned to the locked nixpkgs on purpose. typos' dictionary *is* the product
+  # and grows with every release, so a floating version could turn CI red with no
+  # change to the repo at all. Runs unwrapped, so it sees only the committed
+  # `.typos.toml` — never the private global layer.
+  mkCheck =
+    src:
+    pkgs.runCommand "typos-check" { nativeBuildInputs = [ pkgs.typos ]; } ''
+      cd ${src}
+      typos --color always
+      touch "$out"
+    '';
+}

--- a/shells/darwin-install.nix
+++ b/shells/darwin-install.nix
@@ -10,6 +10,7 @@ let
     module = import "${self}/programs/nvim";
     extraSpecialArgs = {
       profile = "nix";
+      root = self;
     };
   };
   claudeCode = import "${self}/lib/claude-code.nix" {

--- a/shells/nixos-install.nix
+++ b/shells/nixos-install.nix
@@ -11,6 +11,7 @@ let
     module = import "${self}/programs/nvim";
     extraSpecialArgs = {
       profile = "sops";
+      root = self;
     };
   };
   claudeCode = import "${self}/lib/claude-code.nix" {


### PR DESCRIPTION
- Fixes: #96 