### PR TITLE
herdr: prefix+alt+1..9 to jump between agents

### DIFF
--- a/modules/home/herdr.nix
+++ b/modules/home/herdr.nix
@@ -34,6 +34,14 @@ let
       # ctrl+b is Claude Code's "background this command"; ctrl+x only shadows
       # things with an easy escape hatch (press it twice to send it through).
       prefix = "ctrl+x";
+
+      # Jump straight to a sidebar agent by position: prefix, then alt+N.
+      # "1..9" is herdr's only range token, and alt is what keeps the bare
+      # prefix+1..9 digits on switch_tab — a user binding silently wins over a
+      # default one, so without alt this would take tab switching away.
+      # Positions follow the sidebar (workspace, then tab, then pane) and skip
+      # panes with no agent, so they stay put as long as the layout does.
+      focus_agent = "prefix+alt+1..9";
     };
   };
 in


### PR DESCRIPTION
Closes #132.

`ctrl+x` then `alt+3` focuses the third agent in the sidebar. `ctrl+x` then `3` still switches to tab 3.

## Why not the config in the issue

The snippet on the issue can't work, for three separate reasons:

1. **The schema is inverted.** herdr's `[keys]` table maps *action → binding*, not binding → action. Unknown keys like `"prefix+a+1"` are simply ignored.
2. **There are no three-level chords.** `parse_binding_string` strips one optional `prefix+` and parses the rest as a single key combo, so `a+1` fails to parse and the binding is disabled.
3. **There is no `focus_agent_1` action.** Indexed actions are single fields taking a range, and the only legal range token is literally `1..9`.

## Why `alt`

`switch_tab` defaults to `prefix+1..9`. A user binding silently wins over a conflicting default — no error, the default just disappears — so binding the bare digits to `focus_agent` would have taken tab switching away without saying so. `alt` sidesteps it, and Ghostty here sets `macos-option-as-alt`, so alt chords reach herdr on macOS.

`next_agent` / `previous_agent` are left unbound; agents past the 9th are reachable through the `prefix+g` picker.

## Ordering

`ui.agent_panel_sort` stays at its `"spaces"` default, so positions follow the sidebar (workspace → tab → pane) and stay put. The alternative, `"priority"`, sorts blocked-first — handy, but it means the indices reshuffle as agents change state, killing muscle memory.

Panes with no detected agent are skipped by `pane_details`, so a plain shell pane never consumes a number.

## Verification

- `just check` passes.
- Built the generated file from the real `macos-main` config and read it back — `focus_agent = "prefix+alt+1..9"` is present.
- Ran `herdr config check` against that store path: `config: ok`.
- Confirmed the check is meaningful by feeding it the issue's original syntax: `invalid keybinding: keys.focus_agent = "prefix+a+1"; disabling binding`.

That last point is the real risk this guards against — herdr disables an unparseable binding with a log line and otherwise starts up fine, so a broken binding looks like a working config. Wiring `herdr config check` in as a flake check would catch that in CI; happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)