### PR TITLE
Track the darwin nixpkgs channel and guard against expensive rebuilds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,19 @@ updates:
       day: "friday"
     ignore:
       - dependency-name: "lanzaboote"
-    # Two groups, not one. A nixpkgs rev whose darwin closure is not cached
+    # Three groups, not one. A nixpkgs rev whose darwin closure is not cached
     # fails `just darwin-cache-check`, and under a single group that red PR
     # would also hold back the cheap tool bumps - which is exactly what forced
-    # the wholesale revert in 58f2f8e. Splitting lets tools land while nixpkgs
-    # waits for a rev the guard accepts.
+    # the wholesale revert in 58f2f8e. Splitting lets the rest land while
+    # nixpkgs waits for a rev the guard accepts.
     # See docs/adr/0004-darwin-tracks-the-darwin-channel.md.
+    #
+    # `ungrouped` is a catch-all, so a new flake input can never go un-updated
+    # by falling outside the curated groups - the worst it can do is arrive in
+    # a PR of its own. Dependabot has no group-reference syntax, so its
+    # exclude-patterns restate the curated memberships by hand; keep the two
+    # lists in step. Those excludes are what keep the groups disjoint, not the
+    # order they are declared in.
     groups:
       # Everything whose version is decided by, or moves in step with, nixpkgs.
       nixpkgs-core:
@@ -23,13 +30,33 @@ updates:
           - "nix-darwin"
           - "sops-nix"
           - "disko"
-      # Self-contained and cheap to rebuild. llm-agents deliberately does not
-      # follow nixpkgs (see flake.nix) and mattpocock-skills is `flake = false`.
-      tools:
+      # Agent tooling: the agent packages, their workspace manager, and every
+      # skill source. All self-contained and cheap to rebuild - llm-agents
+      # deliberately does not follow nixpkgs (see flake.nix), skill repos are
+      # `flake = false`, and herdr is a Rust TUI that rebuilds in minutes.
+      # The glob means a new skill source is picked up without editing this.
+      ai:
         patterns:
-          - "herdr"
           - "llm-agents"
-          - "mattpocock-skills"
+          - "herdr"
+          - "*skills*"
+      # Anything not classified above, so nothing is ever left un-updated. It
+      # matches nothing today; an input landing here is the prompt to decide
+      # whether it belongs in a curated group, not a failure. `lanzaboote` is
+      # in `ignore` above, so it stays out of this and every other group.
+      ungrouped:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "nixpkgs"
+          - "home-manager"
+          - "nixvim"
+          - "nix-darwin"
+          - "sops-nix"
+          - "disko"
+          - "llm-agents"
+          - "herdr"
+          - "*skills*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,29 @@ updates:
       day: "friday"
     ignore:
       - dependency-name: "lanzaboote"
+    # Two groups, not one. A nixpkgs rev whose darwin closure is not cached
+    # fails `just darwin-cache-check`, and under a single group that red PR
+    # would also hold back the cheap tool bumps - which is exactly what forced
+    # the wholesale revert in 58f2f8e. Splitting lets tools land while nixpkgs
+    # waits for a rev the guard accepts.
+    # See docs/adr/0004-darwin-tracks-the-darwin-channel.md.
     groups:
-      nix-updates:
+      # Everything whose version is decided by, or moves in step with, nixpkgs.
+      nixpkgs-core:
         patterns:
-          - "*"
+          - "nixpkgs"
+          - "home-manager"
+          - "nixvim"
+          - "nix-darwin"
+          - "sops-nix"
+          - "disko"
+      # Self-contained and cheap to rebuild. llm-agents deliberately does not
+      # follow nixpkgs (see flake.nix) and mattpocock-skills is `flake = false`.
+      tools:
+        patterns:
+          - "herdr"
+          - "llm-agents"
+          - "mattpocock-skills"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,3 +22,24 @@ jobs:
 
       - name: Run checks
         run: nix shell nixpkgs#just nixpkgs#statix nixpkgs#deadnix --command just check
+
+  # Refuses a dependency bump that would make the next darwin-rebuild take
+  # hours. Runs on Linux on purpose: `nix build --dry-run` only queries
+  # substituters, so an aarch64-darwin plan needs no darwin builder.
+  # See docs/adr/0004-darwin-tracks-the-darwin-channel.md.
+  cache-guard:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          # Must mirror modules/nix.nix, or the guard reports a miss for
+          # anything that is only on the numtide cache.
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            extra-substituters = https://cache.numtide.com
+            extra-trusted-public-keys = niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=
+
+      - name: Guard against expensive local rebuilds
+        run: nix shell nixpkgs#just --command just darwin-cache-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,18 @@ Helpers that compose inputs, modules, and hosts into complete NixOS/Darwin syste
 3. Register the HM module in `modules/home/default.nix`.
 4. Optionally import `programs/<name>` directly in any `shells/` that need it.
 
+## Dependency Updates
+
+**`nixpkgs` tracks `nixpkgs-26.05-darwin`, not `nixos-26.05`. That is deliberate - do not "fix" it.**
+
+Both branches fast-forward along `release-26.05`, but different Hydra jobsets advance them, so they land on different revisions. A rev from `nixos-26.05` is guaranteed to have *Linux* binaries in `cache.nixos.org`; darwin coverage is incidental. One such rev cost hours of Swift and .NET compilation and had to be reverted (`987b09a` → `58f2f8e`). See `docs/adr/0004-darwin-tracks-the-darwin-channel.md`; `lenovo-old`'s side of that trade is tracked in `docs/NON-DARWIN-NIXOS-ISSUES.md`.
+
+`just darwin-cache-check` dry-runs the `macos-main` closure and fails if anything in `just/nix-darwin/expensive-builds.deny` would be built locally. Run it before pulling a dependency bump; CI runs it on every PR in the `cache-guard` job. It runs on Linux because `--dry-run` only queries substituters and never needs a darwin builder, but the substituter list in the workflow must stay in sync with `modules/nix.nix`, or it reports false misses.
+
+The denylist is a plain pattern-per-line file, edited by hand. Anchor every pattern with `^`: unanchored, `go-1\.` also matches car`go-1.9`6.1-aarch64-apple-darwin, which herdr's rust-overlay toolchain builds every time. The recipe self-tests its own pipeline against a synthetic plan before trusting a real one, because both of its failure modes report a bad plan as clean.
+
+Dependabot splits nix inputs into `nixpkgs-core` and `tools` so a nixpkgs rev the guard rejects does not also hold back herdr, llm-agents and the skills.
+
 ## Agent Configuration
 
 **`programs/agents/` is agent-agnostic. Agent-specific code lives in that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Both branches fast-forward along `release-26.05`, but different Hydra jobsets ad
 
 The denylist is a plain pattern-per-line file, edited by hand. Anchor every pattern with `^`: unanchored, `go-1\.` also matches car`go-1.9`6.1-aarch64-apple-darwin, which herdr's rust-overlay toolchain builds every time. The recipe self-tests its own pipeline against a synthetic plan before trusting a real one, because both of its failure modes report a bad plan as clean.
 
-Dependabot splits nix inputs into `nixpkgs-core` and `tools` so a nixpkgs rev the guard rejects does not also hold back herdr, llm-agents and the skills.
+Dependabot splits nix inputs into `nixpkgs-core` (guard-gated), `ai` (agent tooling and skill sources) and `ungrouped` (a catch-all matching everything else), so a nixpkgs rev the guard rejects does not also hold back herdr, llm-agents and the skills, and an input nobody classified still gets updates instead of silently freezing. `ungrouped` restates the other two memberships in `exclude-patterns` because dependabot has no group-reference syntax; keep them in step.
 
 ## Agent Configuration
 

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,7 @@ import 'just/nixos/live-iso.just'
 import 'just/nixos/post-boot.just'
 import 'just/nix-darwin/install.just'
 import 'just/nix-darwin/post-install.just'
+import 'just/nix-darwin/cache-check.just'
 
 # Show available recipes
 default:

--- a/docs/NON-DARWIN-NIXOS-ISSUES.md
+++ b/docs/NON-DARWIN-NIXOS-ISSUES.md
@@ -1,0 +1,48 @@
+# Non-darwin (NixOS) issues
+
+Open items for `lenovo-old` created by decisions taken for the macOS hosts.
+Nothing here is known to be broken - these are consequences that were accepted
+without being measured, because macOS is the daily driver and the NixOS box is
+rebuilt rarely.
+
+Context: `docs/adr/0004-darwin-tracks-the-darwin-channel.md`.
+
+## The single nixpkgs input now tracks the darwin channel
+
+`flake.nix` pins `github:NixOS/nixpkgs/nixpkgs-26.05-darwin`. Both hosts share
+that one input, so `lenovo-old` is built from a branch whose revisions were
+chosen by Hydra's *darwin* jobset. `nixos-26.05` and `nixpkgs-26.05-darwin` both
+fast-forward along `release-26.05` but land on different revisions, so an
+x86_64-linux closure at a darwin channel head has no guarantee of being in
+`cache.nixos.org` - the mirror image of the problem this fixed for macOS.
+
+- [ ] Measure it. On any machine:
+      `nix build --dry-run .#nixosConfigurations.lenovo-old.config.system.build.toplevel`
+      and read the "will be built" list. `--dry-run` only queries substituters,
+      so this needs no Linux builder and can run from macOS.
+- [ ] If the list is small and cheap, close this out and record the number here.
+- [ ] If it is not, add a `nixos-cache-check` recipe next to
+      `just/nix-darwin/cache-check.just`, reusing
+      `just/nix-darwin/expensive-builds.deny`. The denylist is
+      platform-agnostic; only the flake attribute differs. Note that the two
+      recipes would then duplicate the extraction pipeline, so factor it out
+      rather than copying it.
+- [ ] Only if the misses are genuinely expensive: split the input. Add
+      `nixpkgs-linux.url = "github:NixOS/nixpkgs/nixos-26.05"`, have
+      `mkNixosSystem` pass it as `nixpkgs.pkgs`, and repoint the `follows` of
+      every flake the NixOS host uses (`home-manager`, `disko`, `sops-nix`,
+      `lanzaboote`). This roughly doubles the lock and the eval cost, which is
+      why it was not done up front.
+
+## Secondary
+
+- [ ] `lanzaboote` is excluded from dependabot (`.github/dependabot.yml`) and is
+      pinned to the `v1.0.0` tag. It only matters for secure boot on
+      `lenovo-old`. Decide whether that pin should ever move, or make the reason
+      for freezing it explicit in `flake.nix`.
+- [ ] `nix flake check` evaluates `lenovo-old` ("checking NixOS configuration
+      'nixosConfigurations.lenovo-old'"), so breakage there is caught. It does
+      *not* descend into `darwinConfigurations`, which is not an output type it
+      knows - the darwin hosts are only evaluated because
+      `just darwin-cache-check` builds a plan for `macos-main`. Nothing
+      evaluates `macos-work`, though it shares every module with `macos-main`.

--- a/docs/adr/0004-darwin-tracks-the-darwin-channel.md
+++ b/docs/adr/0004-darwin-tracks-the-darwin-channel.md
@@ -96,6 +96,11 @@ Hydra-built path and HLS gets built from source - a worse outcome than the Swift
 one, since it is the entire Haskell package set. The denylist covers it, so the
 guard will say so rather than the laptop discovering it.
 
-Dependabot is split into a `nixpkgs-core` group and a `tools` group for the same
-reason the revert hurt: with one group, a nixpkgs rev the guard rejects also
-holds back herdr, llm-agents and the skills.
+Dependabot is split for the same reason the revert hurt: with one group, a
+nixpkgs rev the guard rejects also holds back herdr, llm-agents and the skills.
+`nixpkgs-core` is the expensive, guard-gated group; `ai` is the agent tooling;
+`ungrouped` is a catch-all matching everything else, so an input that nobody
+classified still gets updates instead of silently freezing. Dependabot has no
+group-reference syntax, so `ungrouped`'s exclude-patterns restate the other two
+memberships by hand - those excludes are what keep the groups disjoint, not the
+order they are declared in.

--- a/docs/adr/0004-darwin-tracks-the-darwin-channel.md
+++ b/docs/adr/0004-darwin-tracks-the-darwin-channel.md
@@ -1,0 +1,101 @@
+# nixpkgs tracks the darwin channel, not nixos-26.05
+
+`flake.nix` pins `github:NixOS/nixpkgs/nixpkgs-26.05-darwin`. That looks like a
+typo for `nixos-26.05` and it is not. This records why, and what a CI guard is
+doing next to it.
+
+## What went wrong
+
+`987b09a` bumped nixpkgs to `02e08985`. The rebuild started compiling Swift
+5.10.1 and .NET's source-build VMR, which is hours of work on a laptop, so the
+bump was reverted wholesale in `58f2f8e` - taking four unrelated tool updates
+down with it.
+
+The chain, from `nix why-depends`:
+
+```
+darwin-system → activation-<user> → home-manager-generation → home-manager-path
+  → pre-commit-4.5.1            (modules/home/git.nix)
+    → dotnet-sdk-wrapped-8.0.423
+      → dotnet-vmr-8.0.29
+        → swift-wrapper-5.10.1
+```
+
+nixpkgs' `pre-commit` carries `dotnet-sdk` in its `nativeCheckInputs`, because
+its test suite exercises dotnet hooks, and darwin's `dotnet-vmr` is built with
+Swift. None of that is in pre-commit's *runtime* closure, so it costs nothing at
+all - right up until `pre-commit` itself has to be built from source. Then the
+whole tail comes with it.
+
+`herdr` was the initial suspect and was not the cause. It does rebuild on every
+bump, because `inputs.nixpkgs.follows = "nixpkgs"` makes its derivation hash
+unique to our pin so no upstream artifact can ever match it, but it is a Rust
+TUI and a zig `libghostty-vt` cache: minutes.
+
+## Why the rev had no binaries
+
+`cache.nixos.org` for `pre-commit-4.5.1` on aarch64-darwin:
+
+| nixpkgs rev | store path | narinfo |
+| --- | --- | --- |
+| `531670d` (before the bump) | `yd00x54l...` | 200 |
+| `02e08985` (the bump) | `891ky604...` | **404** |
+| `b18a4b9` (the next proposal) | `yy35ziav...` | 200 |
+
+`nixos-26.05` and `nixpkgs-26.05-darwin` both fast-forward along
+`release-26.05`, but different Hydra jobsets advance them: the NixOS/Linux
+jobset advances the first, the darwin jobset the second. They land on different
+revisions. So a rev taken from `nixos-26.05` is guaranteed to have *Linux*
+binaries and merely tends to have darwin ones. `02e08985` is an ancestor of both
+branches yet was never a darwin channel head, so its darwin closure was never
+built. Nine days later it is still a 404: this is not Hydra lag that resolves
+itself.
+
+Tracking the darwin channel makes the guarantee match the machine that consumes
+it. Every rev dependabot can now propose is one the darwin jobset actually
+evaluated.
+
+## Why there is a guard as well
+
+The channel switch removes the common case, not every case. A package can still
+fail to build in the darwin jobset, and anything reachable only through our own
+flake inputs was never in any jobset. `just darwin-cache-check` dry-runs the
+`macos-main` closure and fails on a denylist of derivations that cost hours:
+Swift, .NET, the GHC/HLS set, LLVM, browser engines. It runs on the Linux CI
+runner, because `--dry-run` only queries substituters and never needs a darwin
+builder.
+
+The denylist is `just/nix-darwin/expensive-builds.deny`, a plain
+pattern-per-line file meant to be edited by hand. Two traps are recorded in it:
+patterns must be anchored, or `go-1\.` also matches
+car`go-1.9`6.1-aarch64-apple-darwin, and nixpkgs' own `rustc`/`cargo` must be
+distinguished from the rust-overlay toolchain herdr pulls in, which is only a
+tarball unpack and is built every single time.
+
+Both of the guard's failure modes are silent - a denylist that matches nothing
+and an extractor that yields nothing both report every plan as clean - so the
+recipe runs its own pipeline over a synthetic plan with known answers before it
+will vouch for a real one. That self-test earned its place immediately: the
+first version terminated its range on `/will be fetched:/` while nix actually
+prints `will be fetched (3.3 GiB download, ...):`, so the fetch list was being
+scanned as if it were the build list.
+
+## Consequences
+
+`lenovo-old` now rides on a nixpkgs branch validated for darwin rather than for
+Linux, and may see cache misses of its own. That was accepted deliberately
+rather than solved: the alternative is a second nixpkgs input plus per-system
+`follows` for every shared flake, which doubles the lock to serve a machine that
+is rebuilt rarely. `docs/NON-DARWIN-NIXOS-ISSUES.md` tracks what to do if it
+starts hurting.
+
+`modules/home/languages/haskell.nix` hard-pins `haskell.packages.ghc9103`. That
+is currently also nixpkgs' default `haskellPackages` compiler, which is the only
+reason HLS is a cache hit. When nixpkgs moves its default, that set leaves the
+Hydra-built path and HLS gets built from source - a worse outcome than the Swift
+one, since it is the entire Haskell package set. The denylist covers it, so the
+guard will say so rather than the laptop discovering it.
+
+Dependabot is split into a `nixpkgs-core` group and a `tools` group for the same
+reason the revert hurt: with one group, a nixpkgs rev the guard rejects also
+holds back herdr, llm-agents and the skills.

--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785719327,
-        "narHash": "sha256-QEx40plgXYSDMo0ll/2HbvIKoaq/bUhCJ1TKq21ChjQ=",
+        "lastModified": 1787445896,
+        "narHash": "sha256-doshBngyEhRZp9OnmAZkZv54L75pFkSFRBSp3JUX/x0=",
         "owner": "ogulcancelik",
         "repo": "herdr",
-        "rev": "eacea2daf0b72973173b728936b27478374f2cd2",
+        "rev": "d6dae88345d24b8e468f63faad6a09173d2cbeac",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785119570,
-        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
+        "lastModified": 1787377438,
+        "narHash": "sha256-Sxu1NLTD/Ern6hFGLlZmtKCSct3YQXZI/lls8RE1XeM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
+        "rev": "65258d5c65a250189fde2e35f490d15e064c4c62",
         "type": "github"
       },
       "original": {
@@ -223,11 +223,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1785145739,
-        "narHash": "sha256-qX/t+D9uVsMw32Za6oXcgXWn6d2HGZqEzMlZWnVQ4GM=",
+        "lastModified": 1787522224,
+        "narHash": "sha256-48PaGCena40RwOvU7K/Eb/PJyMo2gz71Dqkc+CFpYhE=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "259abb89d0a0d3ba685987053ad344534a5d6600",
+        "rev": "3c16acbe5229040ee8f4d6f7b85de757e14b4bda",
         "type": "github"
       },
       "original": {
@@ -239,11 +239,11 @@
     "mattpocock-skills": {
       "flake": false,
       "locked": {
-        "lastModified": 1785230297,
-        "narHash": "sha256-dQtG6usJWlg/FqTajrjcs8GSdymH92WsgLiUaCfvKPA=",
+        "lastModified": 1787309793,
+        "narHash": "sha256-FPAAotNqA5aHrFDlj/XddoLs4TDKi+4J5H/mvevlOlk=",
         "owner": "mattpocock",
         "repo": "skills",
-        "rev": "2ab958093e83e0ec752e6c1c5932da465bf23e0c",
+        "rev": "5b15a47f2d7150f545fbcacbfe381787fc0230dc",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785110946,
-        "narHash": "sha256-WWuWxmXKzGZWryswWlijP3Mjp6aGy4Ngmeil5nGMMjk=",
+        "lastModified": 1787209939,
+        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3498f786f97ac0bded21b34bae0bf3809b45aa3",
+        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
         "type": "github"
       },
       "original": {
@@ -291,16 +291,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1785734586,
-        "narHash": "sha256-ODZkEK9Gy50yg6h98u7KkitZ3oc/uuTFK00bh1CRdNA=",
+        "lastModified": 1787323337,
+        "narHash": "sha256-PqomwlB2WugM9MC4tV1L2/yosMOfug3KBDjmqOqD1bU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
+        "rev": "6062ba1a1b8b6281b12533c9075a2dbeb38f7e49",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-26.05",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -314,11 +314,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1782919967,
-        "narHash": "sha256-pRwjfB5HQJ3m8J8bOR43pPHtHI7VUJSqwLA3P06cOY0=",
+        "lastModified": 1786873773,
+        "narHash": "sha256-Hj/nkhKDv0aJly1PAUstrhrgEYn1mVSkLIYMh90r/Pc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "667c8471f4a0fb24d702d1a61af8609f1a5f1ba6",
+        "rev": "b397fb9f6950d57355d62bb92457d223464e0115",
         "type": "github"
       },
       "original": {
@@ -414,11 +414,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
         "type": "github"
       },
       "original": {
@@ -465,11 +465,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784369104,
-        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "lastModified": 1786901030,
+        "narHash": "sha256-WSFCsDSE5ffgD2MqzkM2CYjeFiKhRF/dJUN8uedb6YE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "rev": "27b3b12a8e6375f28ebe122f07d230ca5459bbfa",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,15 @@
   description = "NixOS & dev-shell configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    # Tracks the *darwin* channel branch, not nixos-26.05. Both fast-forward
+    # along release-26.05, but different Hydra jobsets advance them: the
+    # NixOS/Linux one advances nixos-26.05, the darwin one advances
+    # nixpkgs-26.05-darwin. A rev on nixos-26.05 is only guaranteed to have
+    # *Linux* binaries in cache.nixos.org; darwin coverage is incidental, and a
+    # miss means building Swift and .NET from source for hours.
+    # See docs/adr/0004-darwin-tracks-the-darwin-channel.md before repointing
+    # this, and docs/NON-DARWIN-NIXOS-ISSUES.md for what it costs lenovo-old.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     nixvim = {
       url = "github:nix-community/nixvim/nixos-26.05";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/just/nix-darwin/cache-check.just
+++ b/just/nix-darwin/cache-check.just
@@ -1,0 +1,97 @@
+# ─── Nix Darwin - Cache Guard ────────────────────────────────────────────────
+# Refuses a dependency bump whose build plan contains something too expensive to
+# build locally. Run it before pulling a bump; CI runs it on every PR.
+# See docs/adr/0004-darwin-tracks-the-darwin-channel.md for why this exists.
+
+# Fail if rebuilding macos-main would build anything on the expensive-builds denylist.
+darwin-cache-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    main() {
+        local denylist plan offenders
+
+        denylist="$(denylist_regex)"
+        assert_guard_works "$denylist"
+
+        plan="$(build_plan)"
+        grep -E 'will be (built|fetched)' <<<"$plan" || true
+
+        offenders="$(derivations_to_build <<<"$plan" | grep -E "$denylist" || true)"
+        [ -z "$offenders" ] || reject "$offenders"
+
+        echo "darwin-cache-check: nothing on the denylist would be built."
+    }
+
+    # macos-main and macos-work share every module and differ only in hostname,
+    # user and nix.enable, so one host covers both. Evaluating an aarch64-darwin
+    # closure needs no darwin builder: --dry-run only queries substituters, so
+    # this runs on the Linux CI runner. nix prints the plan to stderr.
+    build_plan() {
+        nix build --dry-run .#darwinConfigurations.macos-main.system 2>&1
+    }
+
+    # A cold store makes "will be built" mean "substitutable nowhere", which is
+    # exactly the cache-miss set we care about. Match the headers without their
+    # trailing colon: the fetch one reads "will be fetched (3.3 GiB download...):".
+    derivations_to_build() {
+        awk '/will be built/ { inside = 1; next } /will be fetched/ { inside = 0 } inside' \
+            | strip_store_prefix
+    }
+
+    denylist_regex() {
+        grep -vE '^[[:space:]]*(#|$)' just/nix-darwin/expensive-builds.deny | paste -sd'|' -
+    }
+
+    strip_store_prefix() {
+        sed 's#^.*/[a-z0-9]\{32\}-##'
+    }
+
+    # Both ways this guard can break are silent: a denylist that matches nothing
+    # and an extractor that yields nothing each report every plan as clean. Run
+    # the real pipeline over a plan with known answers before trusting it.
+    assert_guard_works() {
+        local denylist="$1" flagged
+        flagged="$(sample_plan | derivations_to_build | grep -E "$denylist" || true)"
+
+        if ! grep -qx 'swift-5\.10\.1\.drv' <<<"$flagged"; then
+            refuse_to_vouch "swift was not flagged in a plan that builds it"
+        fi
+        if grep -q 'cargo-' <<<"$flagged"; then
+            refuse_to_vouch "the rust-overlay cargo tarball was flagged; herdr always builds it"
+        fi
+        if grep -q 'ghc-' <<<"$flagged"; then
+            refuse_to_vouch "the fetched list leaked into the built list"
+        fi
+    }
+
+    # A build section holding one denylisted derivation and one lookalike that
+    # must not match, followed by a fetch section that must be ignored entirely.
+    sample_plan() {
+        cat <<'PLAN'
+    these 2 derivations will be built:
+      /nix/store/zdgs26mvv9ps946j4i4n062msxw244p7-swift-5.10.1.drv
+      /nix/store/wf2w7wal5lnw5zlfxcvhg2kygwiwgsr5-cargo-1.96.1-aarch64-apple-darwin.drv
+    these 1 paths will be fetched (1.0 GiB download, 2.0 GiB unpacked):
+      /nix/store/hcvahi0qri0sl0kw6c3xsii9cslmhn0k-ghc-9.10.3
+    PLAN
+    }
+
+    refuse_to_vouch() {
+        echo "darwin-cache-check: self-test failed - $1." >&2
+        echo "The guard cannot be trusted in this state; fix it before relying on a pass." >&2
+        exit 1
+    }
+
+    reject() {
+        echo "" >&2
+        echo "darwin-cache-check: these are on the denylist and would be built locally:" >&2
+        printf '%s\n' "$1" | sed 's/^/  /' >&2
+        echo "" >&2
+        echo "That is hours of rebuild, not minutes. Do not merge this bump - wait for a" >&2
+        echo "nixpkgs rev whose darwin closure is in the cache, or add a substituter that" >&2
+        echo "has it. See docs/adr/0004-darwin-tracks-the-darwin-channel.md." >&2
+        exit 1
+    }
+
+    main

--- a/just/nix-darwin/expensive-builds.deny
+++ b/just/nix-darwin/expensive-builds.deny
@@ -1,0 +1,51 @@
+# Derivations that must never be built locally: each one is hours, not minutes.
+#
+# Extended regexes, one per line, anchored at the start of the derivation NAME
+# (`darwin-cache-check` strips the /nix/store/<hash>- prefix before matching).
+# Blank lines and lines starting with # are ignored. Edit freely - the recipe
+# canary-tests the matcher on every run, so a broken regex fails loudly instead
+# of silently passing every plan.
+#
+# Anchor with ^ or a pattern will match mid-name: an unanchored `go-1\.` also
+# matches car`go-1.9`6.1-aarch64-apple-darwin, which is a cheap tarball unpack.
+
+# Swift, and .NET's source-build VMR which pulls Swift in on darwin.
+# Reachable from pre-commit via its nativeCheckInputs. See ADR 0004.
+^swift
+^swiftpm
+^dotnet
+
+# The Haskell toolchain behind modules/home/languages/haskell.nix. Hydra's
+# darwin jobset builds this set only while ghc9103 stays nixpkgs' default
+# haskellPackages compiler; the day it moves, this fires.
+^ghc-9
+^ghcide
+^haskell-language-server
+^hls-
+
+# Compilers and language runtimes. clang-wrapper is cheap and deliberately
+# not matched; clang-unwrapped and a bare clang-<version> are not.
+^llvm-[0-9]
+^clang-unwrapped
+^clang-[0-9]
+^nodejs-[0-9]
+^go-1\.
+^zig-[0-9]
+^openjdk
+
+# nixpkgs' own rustc/cargo, built from source. The rust-overlay toolchain that
+# herdr pulls in is named rustc-<version>-<triple> and is only a tarball
+# unpack, so the trailing anchor keeps it out.
+^rustc-[0-9.]+\.drv$
+^cargo-[0-9.]+\.drv$
+
+# Browser engines and desktop toolkits.
+^chromium
+^electron-
+^webkitgtk
+^qtbase
+^qtwebengine
+
+# Miscellaneous known multi-hour builds.
+^texlive
+^boost-[0-9]


### PR DESCRIPTION
Supersedes #154.

## The problem

`987b09a` bumped nixpkgs and the rebuild started compiling Swift 5.10.1 and .NET's source-build VMR, so it was reverted wholesale in `58f2f8e`, taking four unrelated tool updates with it.

**It was not herdr.** `nix why-depends`:

```
darwin-system -> ... -> home-manager-path
  -> pre-commit-4.5.1            (modules/home/git.nix:22)
    -> dotnet-sdk-wrapped-8.0.423
      -> dotnet-vmr-8.0.29
        -> swift-wrapper-5.10.1
```

nixpkgs' `pre-commit` carries `dotnet-sdk` in its `nativeCheckInputs`, and darwin's `dotnet-vmr` is built with Swift. None of it is in pre-commit's runtime closure, so it costs nothing until `pre-commit` itself has to be built from source.

Both dependabot commit bodies are stale (the PRs were rebased): `987b09a` says nixpkgs `70cc455` but actually pinned `02e08985`.

`cache.nixos.org`, `pre-commit-4.5.1`, aarch64-darwin:

| nixpkgs rev | store path | narinfo |
| --- | --- | --- |
| `531670d` (before) | `yd00x54l...` | 200 |
| `02e08985` (the bump) | `891ky604...` | **404** |
| `b18a4b9` (#154) | `yy35ziav...` | 200 |

`nixos-26.05` is advanced by Hydra's NixOS/Linux jobset; darwin binaries come from a separate jobset whose branch is `nixpkgs-26.05-darwin`. The two land on different revisions, so a rev from `nixos-26.05` guarantees *Linux* binaries and only happens to have darwin ones. `02e08985` was never a darwin channel head, and is still a 404 nine days later.

## The change

- `flake.nix` pins `nixpkgs-26.05-darwin`, so every rev dependabot can propose is one the darwin jobset evaluated.
- `nix flake update` to today's heads.
- `just darwin-cache-check` dry-runs the `macos-main` closure and fails on `just/nix-darwin/expensive-builds.deny`, a hand-editable pattern-per-line file. New `cache-guard` CI job runs it on the existing free `ubuntu-24.04-arm` runner: `--dry-run` only queries substituters, so an aarch64-darwin plan needs no darwin builder.
- Dependabot split into three groups: `nixpkgs-core` (guard-gated), `ai` (llm-agents, herdr, `*skills*`), and `ungrouped` (`*` minus the curated members). The catch-all means an input nobody classified still gets updates instead of silently freezing.
- ADR 0004, `docs/NON-DARWIN-NIXOS-ISSUES.md` for the `lenovo-old` side of the trade, CLAUDE.md section.

## Verification

| | result |
| --- | --- |
| guard vs. the `987b09a` plan | **fails**, 25 denylist hits (swift + dotnet) |
| guard vs. this branch | **passes**, 249 built / 3.3 GiB fetched, nothing denylisted |
| `just check` | green |

The guard self-tests its own pipeline against a synthetic plan before trusting a real one, because both of its failure modes report a bad plan as clean. That caught a real bug during development: the first version terminated its range on `/will be fetched:/` while nix prints `will be fetched (3.3 GiB download, ...):`.

Known follow-up, tracked in the ADR and the denylist: `modules/home/languages/haskell.nix` hard-pins `ghc9103`, which is *currently* also nixpkgs' default `haskellPackages` compiler. When nixpkgs moves its default, that set leaves the Hydra-built path and HLS builds from source, which is worse than the Swift case. The guard will say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)